### PR TITLE
Switch between active sessions

### DIFF
--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -42,6 +42,21 @@ plugin.use_entry_processor = function(f)
     table.insert(plugin.entry_processors, f)
 end
 
+local show_active = "sessionizer.show-active"
+plugin.show_active = act.EmitEvent(show_active)
+wez.on(show_active, function(window, pane)
+    local active_workspaces = {}
+    local current = wez.mux.get_active_workspace()
+    for index, item in ipairs(wez.mux.get_workspace_names()) do
+        local label = item
+        if item == current then
+            label = label .. " (Current)"
+        end
+        table.insert(active_workspaces, index, { id = item, label = label })
+    end
+    plugin.display_entries(active_workspaces, window, pane)
+end)
+
 ---@param entries { id: string, label: string }
 plugin.display_entries = function(entries, window, pane)
     local cfg = config.get_effective_config(plugin.config)

--- a/plugin/sessionizer/bindings.lua
+++ b/plugin/sessionizer/bindings.lua
@@ -14,6 +14,11 @@ bindings.apply_binds = function(plugin, config, disable_default_binds)
         action = plugin.show
     })
     add_bind(config, {
+        key = "a",
+        mods = "ALT",
+        action = plugin.show_active
+    })
+    add_bind(config, {
         key = "m",
         mods = "ALT",
         action = plugin.switch_to_most_recent


### PR DESCRIPTION
When I have open multiple sessions at once I was missing a feature for seeing what sessions are open.

This uses the already existing input selector, but with only the currentlly active sessions, not all the entries provided in the config. 