### PR TITLE
Trim CR in FDSearch generator on windows

### DIFF
--- a/plugin/sessionizer/generators/fd_search.lua
+++ b/plugin/sessionizer/generators/fd_search.lua
@@ -23,7 +23,11 @@ local function get_fd_path_auto()
         return
     end
 
-    return stdout:gsub("\n$", "")
+    local cleansed = stdout:gsub("\n$", "")
+    if is_windows then
+        cleansed = cleansed:gsub("\r$", "")
+    end
+    return cleansed
 end
 
 local function normalize_options(opts)


### PR DESCRIPTION
First of all: Great plugin, thanks for your work!

Since I have to use windows on my work machine, I discoverd that there is a small issue with the path discovery of `fd` in the FDSearch generator. (I am using pwsh.exe as shell). Appearantly, `where.exe` returns the discovered path, followed by windows line endings...

I have added an additional `gsub` to remove `\r` on windows.